### PR TITLE
Encapsulated main page in StackView, and added formatting/styling/placements

### DIFF
--- a/PieceOfShift/Chart.qml
+++ b/PieceOfShift/Chart.qml
@@ -146,8 +146,8 @@ Item {
         }
         Button{
             text: "reset"
-            x: 15
-            y: 10
+            x: chartview.x
+            y: Math.max(chartview.y, 35)
             onClicked: {
                 x_axis.min = 0
                 y_axis.min = 0

--- a/PieceOfShift/ControlButtons.qml
+++ b/PieceOfShift/ControlButtons.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.0
 import QtQuick.Controls 2.5
 import QtQuick.Layouts 1.3
+
 Item {
     Rectangle{
         color: "#00ffffff"
@@ -13,6 +14,7 @@ Item {
         radius: 10
 
         Button{
+            id: b1
             text: "Start"
             anchors.left: parent.left
             anchors.top: parent.top
@@ -29,15 +31,38 @@ Item {
                 elide: Text.ElideRight
             }
             background: Rectangle{
+                /*
                 border.width: 3
                 radius: 8
                 color: parent.down ? "#1db552" : "#24d160"
-            }
-            onClicked: {
-
+                */
+                implicitWidth: parent.width
+                implicitHeight: parent.height
+                border.width: 2
+                border.color: "#888"
+                radius: 8
+                opacity: 0.8
+                MouseArea {
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    onClicked: {
+                        mainView.timer.start();
+                    }
+                    onPressed: {
+                        parent.color = "#aaa";
+                    }
+                    onReleased: {
+                        parent.color = "#eee";
+                    }
+                    onHoveredChanged: {
+                        parent.opacity = containsMouse ? 1.0 : 0.8;
+                        cursorShape = containsMouse ? Qt.PointingHandCursor : Qt.ArrowCursor;
+                    }
+                }
             }
         }
         Button{
+            id: b2
             x: 300
             text: "Stop"
             anchors.right: parent.right
@@ -55,12 +80,34 @@ Item {
                 elide: Text.ElideRight
             }
             background: Rectangle{
+                /*
                 border.width: 3
                 radius: 8
                 color: parent.down ? "#cc121e" : "#ff1424"
-            }
-            onClicked: {
-
+                */
+                implicitWidth: parent.width
+                implicitHeight: parent.height
+                border.width: 2
+                border.color: "#888"
+                radius: 8
+                opacity: 0.8
+                MouseArea {
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    onClicked: {
+                        mainView.timer.stop();
+                    }
+                    onPressed: {
+                        parent.color = "#aaa";
+                    }
+                    onReleased: {
+                        parent.color = "#eee";
+                    }
+                    onHoveredChanged: {
+                        parent.opacity = containsMouse ? 1.0 : 0.8;
+                        cursorShape = containsMouse ? Qt.PointingHandCursor : Qt.ArrowCursor;
+                    }
+                }
             }
         }
         Button{
@@ -85,9 +132,24 @@ Item {
                 border.width: 3
                 radius: 8
                 color: parent.down ? "#cc121e" : "#ff1424"
-            }
-            onClicked: {
 
+                MouseArea {
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    onClicked: {
+                        console.log("SHIT");
+                    }
+                    onPressed: {
+                        parent.color = "#cc121e";
+                    }
+                    onReleased: {
+                        parent.color = "#ff1424";
+                    }
+                    onHoveredChanged: {
+                        parent.opacity = containsMouse ? 1.0 : 0.8;
+                        cursorShape = containsMouse ? Qt.PointingHandCursor : Qt.ArrowCursor;
+                    }
+                }
             }
         }
     }

--- a/PieceOfShift/CustomMenuBar.qml
+++ b/PieceOfShift/CustomMenuBar.qml
@@ -2,10 +2,10 @@ import QtQuick 2.12
 import QtQuick.Window 2.3
 import QtQuick.Controls 2.5
 Item {
-    property alias _width: __menu.width
+    //property alias _width: __menu.width Don't need this if we only set width in main.qml
     MenuBar{
         id: __menu
-        width: _width
+        //width: _width
         Menu{
             title: qsTr("&File")
 

--- a/PieceOfShift/DistanceSlider.qml
+++ b/PieceOfShift/DistanceSlider.qml
@@ -10,7 +10,9 @@ Item {
     Slider {
         id: slider
         x: 0.05 * window.width
-        y: 594
+        //y: 594
+        //I suggest for dynamic positioning:
+        y: Math.max(window.height - 60, speedometer.y + speedometer.height);
         width: 0.95 * window.width
         height: 0.08 * height
         font.pointSize: 14
@@ -82,5 +84,4 @@ Item {
 
     }
 }
-
 

--- a/PieceOfShift/PreviewPage.qml
+++ b/PieceOfShift/PreviewPage.qml
@@ -16,32 +16,19 @@ Page {
           */
     }
 
-    Label {
-        id: label
-        text: qsTr("This is an example page with an example chart.")
-    }
-    Button {
-        onClicked: stackView.pop("main.qml")
-        x: detailedChart.chartview.x
-        y: detailedChart.chartview.height + 20
-        text: qsTr("Previous page")
-        font.capitalization: Font.MixedCase
-    }
-
     Chart {
         id: detailedChart
-        x: label.x + 10
-        y: label.y + label.height + 10
-        chartview.width: 400
-        chartview.height: 400
-        chartview.theme: "ChartThemeDark"
+        x: 0
+        y: 0
+        chartview.width: window.width - 100
+        chartview.height: window.height
         /*
           The following function is called when the component (i.e. page) is loaded.
           It will then iterate through the points from the previous graph (in main.qml)
           and add all those points to this graph.
         */
         Component.onCompleted: {
-            let prv_graph = mainView.simpleChart;
+            let prv_graph = mainView.chart;
             for (let i = 0; i < prv_graph.lineseries.count; i++) {
                 let x_point = prv_graph.lineseries.at(i).x
                 let y_point = prv_graph.lineseries.at(i).y
@@ -52,11 +39,16 @@ Page {
 
         //Timer for simulating continously updated points
         Timer {
-            running: true; repeat: true; interval: 1000;
+            running: mainView.timer.running; repeat: true; interval: 200;
             onTriggered: {
-                let increment = mainView.counter;
-                parent.lineseries.append(increment, increment);
-                increment++;
+                update(detailedChart, mainView.counter);
+            }
+
+            function update(chart, globalCounter) {
+                var distance = (Math.random() * 0.03) + 0.1;
+                var speed = (distance * 50) / 0.02;
+                globalCounter++;
+                chart.lineseries.append(globalCounter, speed)
             }
         }
     }

--- a/PieceOfShift/SimpleChart.qml
+++ b/PieceOfShift/SimpleChart.qml
@@ -17,6 +17,8 @@ Item {
         antialiasing: true
         backgroundColor: "transparent"
         titleColor: "white"
+        property var x_max: x_axis.max
+        property var y_max: y_axis.max
 
         MouseArea{
             id: chartMouseArea
@@ -52,24 +54,18 @@ Item {
                 titleText: ""
             }
 
-            XYPoint { x: 0; y: 0 }
-            XYPoint { x: 1.1; y: 2.1 }
-            XYPoint { x: 1.9; y: 3.3 }
-            XYPoint { x: 2.1; y: 2.1 }
-            XYPoint { x: 2.9; y: 4.9 }
-            XYPoint { x: 3.4; y: 3.0 }
-            XYPoint { x: 4.1; y: 3.3 }
-
             onPointAdded: {
                 var new_point = at(index)
                 if(new_point.x > x_axis.max){
-                    x_axis.max = new_point.x + Math.round(x/2)
+                    x_axis.max = new_point.x + Math.round(new_point.x/2)
+                    chartview.x_max = x_axis.max
                 }
                 if(new_point.y > y_axis.max){
-                    y_axis.max = new_point.y+ Math.round(y/2)
+                    y_axis.max = new_point.y+ Math.round(new_point.y/2)
+                    chartview.y_max = y_axis.max
                 }
                 if (new_point.y < y_axis.min) {
-                    y_axis.min = new_point.y - Math.round(y/2)
+                    y_axis.min = new_point.y - Math.round(new_point.y/2)
                 }
             }
 

--- a/PieceOfShift/main.qml
+++ b/PieceOfShift/main.qml
@@ -11,89 +11,119 @@ import shift.datamanagement 1.0
 
 ApplicationWindow {
     id: window
-    width: 1280
-    height: 720
+    width: 1700
+    height: 900
     visible: true
+    //visibility: "FullScreen"
     color: "#444444"
     title: "PieceOfShift"
     menuBar: CustomMenuBar{
-        _width: window.width
+        width: window.width
     }
 
-    Image {
-        id: logoWhite_RightText
-        x: 31
-        y: 50
-        width: 250
-        source: "assets/images/Shift_Logo.png"
-        fillMode: Image.PreserveAspectFit
+    StackView {
+        id: stackView
+        anchors.fill: parent
+
+
+        initialItem: Item {
+
+
+            id: mainView
+
+            property alias timer: timer
+            property alias chart: chart;
+            property alias counter: chart.counter
+
+            Image {
+                id: logoWhite_RightText
+                x: 31
+                y: 50
+                width: 250
+                source: "assets/images/Shift_Logo.png"
+                fillMode: Image.PreserveAspectFit
+            }
+
+            Speedometer {
+                id: speedometer
+                x: 0
+                y: 144
+                width: 306
+                height: 320
+                minValue: 0
+                maxValue: 600
+            }
+
+            Thermometer {
+                id: thermometer
+                x: 1170
+                y: 233
+                scale: 2
+                minValue: 0
+                maxValue: 50
+            }
+
+            DistanceSlider{
+                id: slider
+                minValue: 0
+                maxValue: 100
+                //x: 28
+                //y: Math.max(window.height - 60, speedometer.y + speedometer.height);
+            }
+
+            Timer {
+                id: timer
+                interval: 200
+                running: true
+                repeat: true
+                property var distance: Math.random //What does this var do?
+                onTriggered: update();
+
+                function update(){
+                    var distance = (Math.random() * 0.03) + 0.1;
+                    var speed = (distance * 50) / 0.02;
+                    slider.value = slider.value + distance;
+                    speedometer.value = speed;
+                    thermometer.value = Math.random() * 25 + 25;
+                    chart.counter++;
+                    chart.lineseries.append(chart.counter, speed);
+                }
+            }
+
+            SimpleChart {
+                id: chart
+                chartHeight: 300
+                chartWidth: 700
+                property var counter: 0
+                x: speedometer.width + 50
+                y: 40
+
+                MouseArea {
+                    anchors.fill: parent
+                    onClicked: {
+                        stackView.push("PreviewPage.qml");
+                    }
+                }
+            }
+
+            Text {
+                id: labelText
+                color: "white"
+                width: 300
+                height: 100
+            }
+
+            ControlButtons{
+                height: 200
+                width: 300
+                y: window.height - (height + 100)
+                x: Math.max(window.width - (width + 30), thermometer.x + thermometer.width + 30)
+                //Buttons will stop when colliding with thermometer
+            }
+        }
     }
 
-    Speedometer {
-        id: speedometer
-        x: 49
-        y: 144
-        width: 306
-        height: 320
-        minValue: 0
-        maxValue: 600
-    }
 
-    Thermometer {
-        id: thermometer
-        x: 1170
-        y: 233
-        scale: 2
-        minValue: 0
-        maxValue: 50
-    }
-
-    DistanceSlider{
-        id: slider
-        minValue: 0
-        maxValue: 10
-    }
-
-    Timer {
-        interval: 200
-        running: true
-        repeat: true
-        property var distance: Math.random
-        onTriggered: update()
-    }
-
-    function update(){
-        var distance = (Math.random() * 0.03) + 0.1;
-        var speed = (distance * 50) / 0.02;
-        slider.value = slider.value + distance / 10;
-        speedometer.value = speed;
-        thermometer.value = Math.random() * 25 + 25;
-        chart.counter++;
-        chart.lineseries.append(chart.counter, speed)
-    }
-
-    Chart {
-        id: chart
-        chartHeight: 300
-        chartWidth: 700
-        property var counter: 0
-        x: 300
-        y: 100
-    }
-
-    Text {
-        id: labelText
-        color: "white"
-        width: 300
-        height: 100
-    }
-
-    ControlButtons{
-        height: 200
-        width: 300
-        y: window.height - (height + 100)
-        x: window.width - (width + 150)
-    }
 }
 
 /*##^##

--- a/PieceOfShift/qml.qrc
+++ b/PieceOfShift/qml.qrc
@@ -8,5 +8,8 @@
         <file>CustomMenuBar.qml</file>
         <file>ControlButtons.qml</file>
         <file>DistanceSlider.qml</file>
+        <file>ExampleComponent.qml</file>
+        <file>PreviewPage.qml</file>
+        <file>SimpleChart.qml</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
Main page is encapsulated in StackView, such that pages can be pushed/popped. Added some formatting and styling to slider and buttons, along with placements. Buttons now do something, and graphs update according to eachother (when you press the first graph, it takes you to a bigger, more detailed graph). All components can now be filled by a MouseArea so that one can click the component and be taken to another page that displays more details surrounding that particular component. This is currently illustrated by clicking the first graph.